### PR TITLE
Add basic OCR pipeline skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
+# OCR Pipeline
 
+This repository provides a minimal OCR pipeline demonstrating GPU/CPU fallback.
+It uses a lightweight GPU model (TrOCR) if CUDA is available and falls back to
+Tesseract otherwise.
+
+## Usage
+
+```bash
+pip install -r requirements.txt
+python main.py path_to_image.png
+```

--- a/main.py
+++ b/main.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+from ocr_pipeline.ocr_pipeline import OCRPipeline
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python main.py <image_file>")
+        return
+    image_path = Path(sys.argv[1])
+    data = image_path.read_bytes()
+    pipeline = OCRPipeline()
+    result = pipeline.process_document(data)
+    print(result)
+
+if __name__ == '__main__':
+    main()

--- a/ocr_pipeline/adaptive_model_loader.py
+++ b/ocr_pipeline/adaptive_model_loader.py
@@ -1,0 +1,29 @@
+import torch
+from transformers import TrOCRProcessor, VisionEncoderDecoderModel
+import pytesseract
+
+class AdaptiveModelLoader:
+    def __init__(self, vram_limit_bytes):
+        self.vram_limit = vram_limit_bytes
+        self.gpu_models = {}
+        self.cpu_models = {}
+
+    def load_gpu_models(self):
+        processor = TrOCRProcessor.from_pretrained('microsoft/trocr-small-printed')
+        model = VisionEncoderDecoderModel.from_pretrained('microsoft/trocr-small-printed')
+        model.to('cuda')
+        self.gpu_models['ocr'] = (processor, model)
+
+    def load_cpu_models(self):
+        # pytesseract acts as cpu model
+        self.cpu_models['ocr'] = pytesseract
+
+    def load_for_device(self, device='auto'):
+        if device == 'gpu':
+            if not self.gpu_models:
+                self.load_gpu_models()
+            return self.gpu_models
+        else:
+            if not self.cpu_models:
+                self.load_cpu_models()
+            return self.cpu_models

--- a/ocr_pipeline/device_manager.py
+++ b/ocr_pipeline/device_manager.py
@@ -1,0 +1,29 @@
+import torch
+
+class VRAMMonitor:
+    """Simple VRAM usage monitor using torch.cuda"""
+    def get_usage(self):
+        if not torch.cuda.is_available():
+            return 0
+        return torch.cuda.memory_allocated()
+
+def get_total_vram():
+    if not torch.cuda.is_available():
+        return 0
+    device = torch.cuda.current_device()
+    return torch.cuda.get_device_properties(device).total_memory
+
+class DeviceManager:
+    def __init__(self, vram_threshold):
+        self.vram_threshold = vram_threshold
+        self.gpu_available = torch.cuda.is_available()
+        self.vram_monitor = VRAMMonitor()
+
+    def select_optimal_device(self):
+        if not self.gpu_available:
+            return 'cpu'
+        current_vram = self.vram_monitor.get_usage()
+        total_vram = get_total_vram()
+        if total_vram > 0 and current_vram > self.vram_threshold:
+            return 'cpu'
+        return 'gpu'

--- a/ocr_pipeline/document_analyzer.py
+++ b/ocr_pipeline/document_analyzer.py
@@ -1,0 +1,6 @@
+import magic
+
+class DocumentAnalyzer:
+    def analyze_document_type(self, file_path):
+        mime = magic.from_file(file_path, mime=True)
+        return mime

--- a/ocr_pipeline/language_detector.py
+++ b/ocr_pipeline/language_detector.py
@@ -1,0 +1,14 @@
+from langdetect import detect
+
+class LanguageDetector:
+    SUPPORTED_LANGUAGES = ['de', 'en', 'fr', 'it', 'es']
+    DEFAULT_LANGUAGE = 'en'
+
+    def detect_language(self, text):
+        try:
+            lang = detect(text)
+        except Exception:
+            return self.DEFAULT_LANGUAGE
+        if lang not in self.SUPPORTED_LANGUAGES:
+            return self.DEFAULT_LANGUAGE
+        return lang

--- a/ocr_pipeline/ocr_pipeline.py
+++ b/ocr_pipeline/ocr_pipeline.py
@@ -1,0 +1,30 @@
+import torch
+from .device_manager import DeviceManager
+from .adaptive_model_loader import AdaptiveModelLoader
+from .language_detector import LanguageDetector
+from PIL import Image
+import io
+
+class OCRPipeline:
+    def __init__(self, vram_limit_gb=1):
+        self.vram_limit_bytes = int(vram_limit_gb * 1024 ** 3)
+        self.device_manager = DeviceManager(vram_threshold=self.vram_limit_bytes)
+        self.model_loader = AdaptiveModelLoader(self.vram_limit_bytes)
+        self.language_detector = LanguageDetector()
+
+    def process_document(self, image_bytes):
+        device = self.device_manager.select_optimal_device()
+        models = self.model_loader.load_for_device(device)
+        if device == 'gpu':
+            processor, model = models['ocr']
+            image = Image.open(io.BytesIO(image_bytes)).convert('RGB')
+            pixel_values = processor(images=image, return_tensors='pt').pixel_values
+            pixel_values = pixel_values.to('cuda')
+            with torch.no_grad():
+                generated_ids = model.generate(pixel_values)
+            text = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
+        else:
+            text = models['ocr'].image_to_string(Image.open(io.BytesIO(image_bytes)))
+
+        lang = self.language_detector.detect_language(text)
+        return {"text": text, "language": lang}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+pytesseract
+Pillow
+torch
+transformers
+langdetect
+python-magic


### PR DESCRIPTION
## Summary
- implement initial OCR pipeline with GPU/CPU fallback
- add language detection and device management helpers
- include minimal README and requirements
- provide example `main.py`

## Testing
- `pip install -r requirements.txt` *(failed: Operation cancelled by user)*
- `python main.py` *(failed: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_6846cddb15148328b2fdb9f58b60865b